### PR TITLE
Install ipykernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,6 @@ TODO example to add a conda env, using it's path
 
 ## TODOs
 
-- fix --conda-name option
-- add NeSI in the name of the tool
 - add venv option
 - add singularity option
-- check module exists
 - check conda module not loaded by user

--- a/nesi_jupyter_helpers/add_kernel.py
+++ b/nesi_jupyter_helpers/add_kernel.py
@@ -139,7 +139,7 @@ def add_kernel(
     # add the wrapper script to the kernel dir
     wrapper_script_dest = kernel_dir / "wrapper.bash"
     shutil.move(wrapper_script, wrapper_script_dest)
-    print(f"Added wrapper script in {wrapper_script}")
+    print(f"Added wrapper script in {wrapper_script_dest}")
 
     # modify the kernel description file
     kernel_def = {


### PR DESCRIPTION
This enforces installation of ipykernel using pip. A side change is to reuse the temporary wrapper instead of deleting it and recreatin it.